### PR TITLE
Bundle OpenMCT in docker-compose setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 /*.changes
 config.h
 *.pyc
+npm-debug.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
   openmct:
     image: cbase/cbeam-telemetry-server
     container_name: cbeam-telemetry-server
-    command: node bitraf.js
+    entrypoint: node bitraf.js
     environment:
       MSGFLO_BROKER: 'mqtt://mqtt:1883'
       INFLUX_HOST: influxdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,11 @@ services:
     ports:
       - '127.0.0.1:1883:1883'
     entrypoint: /usr/local/sbin/mosquitto
+  influxdb:
+    image: influxdb
+    container_name: influxdb
+    ports:
+      - '127.0.0.1:8086:8086'
   msgflo:
     build: .
     container_name: bitraf-iot
@@ -14,4 +19,17 @@ services:
     ports:
       - '127.0.0.1:3569:3569'
     links:
+      - mqtt
+  openmct:
+    image: cbase/cbeam-telemetry-server
+    container_name: cbeam-telemetry-server
+    command: node bitraf.js
+    environment:
+      MSGFLO_BROKER: 'mqtt://mqtt:1883'
+      INFLUX_HOST: influxdb
+    ports:
+      - '127.0.0.1:8080:8080'
+      - '127.0.0.1:8082:8082'
+    links:
+      - influxdb
       - mqtt


### PR DESCRIPTION
This way users should be able to get the whole thing:

* Mosquitto
* InfluxDB
* OpenMCT dashboard
* MsgFlo runtime