### PR TITLE
add git to the docker image, since we need to download froma git repo…

### DIFF
--- a/p2k16-label/Dockerfile
+++ b/p2k16-label/Dockerfile
@@ -1,4 +1,6 @@
 FROM python:3.9-slim-bullseye
+RUN apt update
+RUN apt install git
 RUN useradd --create-home --shell /bin/bash app_user
 WORKDIR /home/app_user
 COPY requirements.txt ./


### PR DESCRIPTION
the temporary fix for the brother_ql python module lives in a github repository, as a pull request. This means we need git in the docker image (at least for building), so include it.