### PR TITLE
apt needs --yes when running in a script

### DIFF
--- a/p2k16-label/Dockerfile
+++ b/p2k16-label/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9-slim-bullseye
 RUN apt update
-RUN apt install git
+RUN apt --yes install git
 RUN useradd --create-home --shell /bin/bash app_user
 WORKDIR /home/app_user
 COPY requirements.txt ./


### PR DESCRIPTION
Fixes upon fixes. Add '--yes' to apt so install will (hopefully) work.